### PR TITLE
Use self-hosted GeoLite 2 databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is a Scala library that helps you do GeoIP lookups with the
 [MaxMind GeoLite2](https://www.maxmind.com/en/geoip2-services-and-databases) databases
 
-This service includes GeoLite2 data created by MaxMind, available from [Maxmind](http://www.maxmind.com")
+This service includes GeoLite2 data created by MaxMind, available from [Maxmind](http://www.maxmind.com)
 
 ```scala
 import io.imply.hostbook.GeoLookup

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is a Scala library that helps you do GeoIP lookups with the
 [MaxMind GeoLite2](https://www.maxmind.com/en/geoip2-services-and-databases) databases
 
-This service includes GeoLite2 data created by MaxMind, available from [Maxmind](http://www.maxmind.com">maxmind.com)
+This service includes GeoLite2 data created by MaxMind, available from [Maxmind](http://www.maxmind.com")
 
 ```scala
 import io.imply.hostbook.GeoLookup

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 <img src="https://cloud.githubusercontent.com/assets/1214075/9833710/7f8fe0f6-5956-11e5-9098-1c3f413186f5.png" />
 
 This is a Scala library that helps you do GeoIP lookups with the
-[MaxMind GeoIP](https://www.maxmind.com/en/geoip2-services-and-databases) databases.
+[MaxMind GeoLite2](https://www.maxmind.com/en/geoip2-services-and-databases) databases
+
+This service includes GeoLite2 data created by MaxMind, available from [Maxmind](http://www.maxmind.com">maxmind.com)
 
 ```scala
 import io.imply.hostbook.GeoLookup

--- a/src/main/scala/io/imply/hostbook/GeoLookup.scala
+++ b/src/main/scala/io/imply/hostbook/GeoLookup.scala
@@ -78,6 +78,7 @@ object GeoLookup extends Logging
   def fromFreeDownloadableCityDatabase(cityFile: File): GeoLookup = {
     if (!cityFile.exists()) {
       log.info("Downloading database from[%s] to local file[%s].", freeDownloadableCityDatabase, cityFile)
+      log.info("GeoLite2 data created by MaxMind, available from https://www.maxmind.com")
 
       new File(cityFile.toString + ".tmp." + UUID.randomUUID()).withFinally(_.delete()) { tmpFile =>
         new FileOutputStream(tmpFile).withFinally(_.close()) { out =>

--- a/src/main/scala/io/imply/hostbook/GeoLookup.scala
+++ b/src/main/scala/io/imply/hostbook/GeoLookup.scala
@@ -66,7 +66,9 @@ class GeoLookup(
 
 object GeoLookup extends Logging
 {
-  val freeDownloadableCityDatabase = "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.mmdb.gz"
+  // This is provided under https://creativecommons.org/licenses/by-sa/4.0/legalcode
+  // Please read https://dev.maxmind.com/geoip/geoip2/geolite2/
+  val freeDownloadableCityDatabase = "https://s3.amazonaws.com/static.imply.io/geolite/GeoLite2-City.mmdb.gz"
 
   def fromCityFile(cityFile: File): GeoLookup = {
     val reader = new DatabaseReader.Builder(cityFile).fileMode(FileMode.MEMORY_MAPPED).build()

--- a/src/test/scala/io/imply/hostbook/GeoLookupTest.scala
+++ b/src/test/scala/io/imply/hostbook/GeoLookupTest.scala
@@ -23,7 +23,7 @@ import org.scalatest.ShouldMatchers
 class GeoLookupTest extends FunSuite with ShouldMatchers
 {
   test("GeoLookup, hit") {
-    val lookup = GeoLookup.fromCityFile(new File(getClass.getClassLoader.getResource("GeoIP2-City-Test.mmdb").getPath))
+    val lookup = GeoLookup.fromFreeDownloadableCityDatabase(new File(getClass.getClassLoader.getResource("GeoIP2-City-Test.mmdb").getPath + ".tmp"))
     val result = lookup.lookup("81.2.69.160")
     result.continentCode should be(Some("EU"))
     result.continentName should be(Some("Europe"))

--- a/src/test/scala/io/imply/hostbook/GeoLookupTest.scala
+++ b/src/test/scala/io/imply/hostbook/GeoLookupTest.scala
@@ -23,7 +23,7 @@ import org.scalatest.ShouldMatchers
 class GeoLookupTest extends FunSuite with ShouldMatchers
 {
   test("GeoLookup, hit") {
-    val lookup = GeoLookup.fromFreeDownloadableCityDatabase(new File(getClass.getClassLoader.getResource("GeoIP2-City-Test.mmdb").getPath + ".tmp"))
+    val lookup = GeoLookup.fromCityFile(new File(getClass.getClassLoader.getResource("GeoIP2-City-Test.mmdb").getPath))
     val result = lookup.lookup("81.2.69.160")
     result.continentCode should be(Some("EU"))
     result.continentName should be(Some("Europe"))


### PR DESCRIPTION
Starting in Jan 2020, GeoIP does not provide a public version of the
GeoLite databases. They can be re-distributed with proper attribution
according to https://support.maxmind.com/geolite-faq/general/how-do-i-use-the-geolite2-databases-in-a-product-or-service/